### PR TITLE
feat: migrate Android TV Box integration to adb-shell transport

### DIFF
--- a/custom_components/android_tv_box/camera.py
+++ b/custom_components/android_tv_box/camera.py
@@ -140,11 +140,10 @@ class AndroidTVBoxCameraCoordinator(DataUpdateCoordinator):
             # Pull the file from device to local temp location
             temp_file = f"{temp_dir}/screenshot_{datetime.now().timestamp()}.png"
             
-            # Use adb pull to get the file
-            cmd = ["pull", latest_file, temp_file]
-            result = await self.adb_service._run_command(cmd)
-            
-            if os.path.exists(temp_file):
+            # Use the Python transport to pull the file
+            success = await self.adb_service.pull_file(latest_file, temp_file)
+
+            if success and os.path.exists(temp_file):
                 try:
                     with open(temp_file, 'rb') as f:
                         data = f.read()

--- a/custom_components/android_tv_box/manifest.json
+++ b/custom_components/android_tv_box/manifest.json
@@ -7,7 +7,8 @@
     "uiautomator2>=2.16.23",
     "aiohttp>=3.8.0",
     "aiohttp-cors>=0.7.0",
-    "paho-mqtt>=1.6.0"
+    "paho-mqtt>=1.6.0",
+    "adb-shell>=0.4.4"
   ],
   "dependencies": [],
   "codeowners": ["@bobo"],

--- a/custom_components/android_tv_box/strings.json
+++ b/custom_components/android_tv_box/strings.json
@@ -7,13 +7,14 @@
         "data": {
           "host": "Host",
           "port": "Port",
-          "name": "Name",
-          "adb_path": "ADB Path"
+          "name": "Name"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to Android device. Check that ADB is enabled and the device is accessible.",
+      "adb_not_found": "Home Assistant could not create ADB keys. Check file permissions or configure a custom key path.",
+      "adb_auth_failed": "Authentication failed. Unlock the device and accept the ADB debugging prompt.",
+      "cannot_connect": "Failed to connect to the Android device. Verify network debugging is enabled and reachable.",
       "unknown": "Unexpected error occurred"
     },
     "abort": {

--- a/custom_components/android_tv_box/translations/en.json
+++ b/custom_components/android_tv_box/translations/en.json
@@ -7,13 +7,14 @@
         "data": {
           "host": "Host",
           "port": "Port",
-          "name": "Name",
-          "adb_path": "ADB Path"
+          "name": "Name"
         }
       }
     },
     "error": {
-      "cannot_connect": "Failed to connect to Android device. Check that ADB is enabled and the device is accessible.",
+      "adb_not_found": "Home Assistant could not create ADB keys. Check file permissions or configure a custom key path.",
+      "adb_auth_failed": "Authentication failed. Unlock the device and accept the ADB debugging prompt.",
+      "cannot_connect": "Failed to connect to the Android device. Verify network debugging is enabled and reachable.",
       "unknown": "Unexpected error occurred"
     },
     "abort": {


### PR DESCRIPTION
## Summary
- depend on the adb-shell pure Python transport in the integration manifest
- refactor the ADB service to use AdbDeviceTcp with built-in RSA key handling and file transfer helpers
- update the config flow, integration setup, and translations to surface friendly adb-shell connection errors

## Testing
- python -m compileall custom_components/android_tv_box

------
https://chatgpt.com/codex/tasks/task_e_68cd7a69923483288968e46b8288a8fe