### PR TITLE
chore: add adb-shell dependency to setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ android_tv_box:
 ### Home Assistant Environment
 - **Home Assistant**: Version 2023.1.0 or higher
 - **Ubuntu Container**: Home Assistant running in Ubuntu container (proot-distro)
-- **Python Dependencies**: Automatically installed via integration
+- **Python Dependencies**: Install with `pip install -r requirements.txt` (ensure internet access or use a pre-downloaded `adb-shell` wheel).
 
 ## 📖 Usage Examples
 

--- a/custom_components/android_tv_box/README.md
+++ b/custom_components/android_tv_box/README.md
@@ -136,7 +136,9 @@ apt update && apt install -y \
 python3 -m venv ~/uiauto_env
 source ~/uiauto_env/bin/activate
 pip install --upgrade pip
-pip install uiautomator2 homeassistant
+pip install uiautomator2 adb-shell homeassistant
+
+# adb-shell is downloaded from PyPI, so ensure internet access or have a local wheel ready before running the command.
 
 # Test ADB connection
 adb connect 127.0.0.1:5555

--- a/deploy.sh
+++ b/deploy.sh
@@ -196,12 +196,14 @@ apt update && apt install -y \\
 python3 -m venv ~/uiauto_env
 source ~/uiauto_env/bin/activate
 pip install --upgrade pip
-pip install uiautomator2 homeassistant
+pip install uiautomator2 adb-shell homeassistant
 
 # Test ADB connection
 adb connect 127.0.0.1:5555
 adb devices
 \`\`\`
+
+> **Note:** The `adb-shell` package is fetched from PyPI, so ensure internet connectivity or have a local wheel available before running the command.
 
 ## Testing
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ paho-mqtt>=1.6.0
 
 # Other dependencies
 voluptuous>=0.13.0
+adb-shell>=0.4.4

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -75,7 +75,8 @@ pip install --upgrade pip
 # Install Python dependencies (excluding Home Assistant as it's already installed)
 print_status "Installing Python dependencies..."
 print_status "Note: Home Assistant is already installed, skipping..."
-pip install uiautomator2 aiohttp aiohttp-cors paho-mqtt voluptuous
+print_warning "Ensure internet access or provide a pre-downloaded adb-shell wheel before continuing."
+pip install uiautomator2 adb-shell aiohttp aiohttp-cors paho-mqtt voluptuous
 
 # Test ADB connection
 print_status "Testing ADB connection to Android device..."


### PR DESCRIPTION
## Summary
- add the adb-shell package to requirements and installer scripts so it is pulled in during environment setup
- document the new dependency and the need for internet access (or a cached wheel) across the setup guides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdcefe6f1c8328b3e7e02750ee03a2