### PR TITLE
fix: add adb-shell compatibility shims

### DIFF
--- a/custom_components/android_tv_box/__init__.py
+++ b/custom_components/android_tv_box/__init__.py
@@ -3,7 +3,7 @@ import asyncio
 import logging
 from typing import Any, Dict, Optional
 
-from adb_shell.exceptions import AdbAuthError
+from adb_shell import exceptions as adb_exceptions
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -12,6 +12,12 @@ from .adb_service import ADBConnectionError, ADBKeyError, ADBService
 from .config import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+AdbAuthError = getattr(
+    adb_exceptions,
+    "AdbAuthError",
+    getattr(adb_exceptions, "AuthenticationError", adb_exceptions.AdbError),
+)
 
 PLATFORMS = [
     Platform.MEDIA_PLAYER,

--- a/custom_components/android_tv_box/adb_service.py
+++ b/custom_components/android_tv_box/adb_service.py
@@ -11,7 +11,23 @@ from typing import Any, Dict, List, Optional
 from adb_shell.adb_device import AdbDeviceTcp
 from adb_shell.auth.keygen import keygen
 from adb_shell.auth.sign_pythonrsa import PythonRSASigner
-from adb_shell.exceptions import AdbAuthError, AdbConnectionError, AdbTimeoutError
+from adb_shell import exceptions as adb_exceptions
+
+AdbAuthError = getattr(
+    adb_exceptions,
+    "AdbAuthError",
+    getattr(adb_exceptions, "AuthenticationError", adb_exceptions.AdbError),
+)
+AdbConnectionError = getattr(
+    adb_exceptions,
+    "AdbConnectionError",
+    getattr(adb_exceptions, "ConnectionError", adb_exceptions.AdbError),
+)
+AdbTimeoutError = getattr(
+    adb_exceptions,
+    "AdbTimeoutError",
+    getattr(adb_exceptions, "TcpTimeoutException", adb_exceptions.AdbError),
+)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/android_tv_box/config_flow.py
+++ b/custom_components/android_tv_box/config_flow.py
@@ -3,7 +3,7 @@ import logging
 from typing import Any, Dict, Optional
 
 import voluptuous as vol
-from adb_shell.exceptions import AdbAuthError, AdbConnectionError, AdbTimeoutError
+from adb_shell import exceptions as adb_exceptions
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import config_validation as cv
@@ -13,6 +13,22 @@ from .adb_service import ADBKeyError, ADBService
 from .config import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+AdbAuthError = getattr(
+    adb_exceptions,
+    "AdbAuthError",
+    getattr(adb_exceptions, "AuthenticationError", adb_exceptions.AdbError),
+)
+AdbConnectionError = getattr(
+    adb_exceptions,
+    "AdbConnectionError",
+    getattr(adb_exceptions, "ConnectionError", adb_exceptions.AdbError),
+)
+AdbTimeoutError = getattr(
+    adb_exceptions,
+    "AdbTimeoutError",
+    getattr(adb_exceptions, "TcpTimeoutException", adb_exceptions.AdbError),
+)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {


### PR DESCRIPTION
## Summary
- replace direct adb-shell exception imports with compatibility aliases in the ADB service, config flow, and integration init modules to support legacy and current packages

## Testing
- python -m compileall custom_components/android_tv_box

------
https://chatgpt.com/codex/tasks/task_e_68cdcf4a2d788328b03fe335dc6d8de8