### PR TITLE
fix: prevent dotted backup modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ android_tv_box:
 
 3. **Add the integration** through the UI
 
+> **Cleanup Note:** If you deployed earlier versions of this script, remove any directories named like `android_tv_box.backup.*` from `custom_components` manually—Home Assistant may still try to treat dotted backup folders as integrations.
+
 ## 🔧 Prerequisites
 
 ### Android Device Setup

--- a/deploy.sh
+++ b/deploy.sh
@@ -72,7 +72,8 @@ fi
 print_status "Copying Android TV Box integration..."
 if [ -d "$CUSTOM_COMPONENTS_DIR/android_tv_box" ]; then
     print_warning "Integration already exists. Backing up..."
-    mv "$CUSTOM_COMPONENTS_DIR/android_tv_box" "$CUSTOM_COMPONENTS_DIR/android_tv_box.backup.$(date +%Y%m%d_%H%M%S)"
+    # Keep backups out of Home Assistant's module discovery by avoiding dotted names
+    mv "$CUSTOM_COMPONENTS_DIR/android_tv_box" "$CUSTOM_COMPONENTS_DIR/android_tv_box_backup_$(date +%Y%m%d_%H%M%S)"
 fi
 
 cp -r "custom_components/android_tv_box" "$CUSTOM_COMPONENTS_DIR/"


### PR DESCRIPTION
## Summary
- rename deploy script backups to use underscore-based names that avoid Home Assistant module discovery
- document the requirement to remove older dotted backups from custom_components manually

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cdd21fcce08328b3e7f239b590179e