### PR TITLE
chore: clean legacy backups during deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ android_tv_box:
 
 3. **Add the integration** through the UI
 
-> **Cleanup Note:** If you deployed earlier versions of this script, remove any directories named like `android_tv_box.backup.*` from `custom_components` manually—Home Assistant may still try to treat dotted backup folders as integrations.
+> **Cleanup Note:** Earlier versions of the deploy script left behind directories named like `android_tv_box.backup.*` inside `custom_components`. The current deploy script now relocates those dotted backups automatically; this reminder remains for anyone who copied files manually and may still have old folders lingering.
 
 ## 🔧 Prerequisites
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -68,6 +68,20 @@ if [ ! -d "$CUSTOM_COMPONENTS_DIR" ]; then
     mkdir -p "$CUSTOM_COMPONENTS_DIR"
 fi
 
+# Clean up legacy dotted backups that Home Assistant may still discover
+LEGACY_BACKUPS_DIR="$HA_CONFIG_DIR/android_tv_box_legacy_backups"
+mapfile -t LEGACY_BACKUPS < <(find "$CUSTOM_COMPONENTS_DIR" -maxdepth 1 -type d -name 'android_tv_box.backup.*' 2>/dev/null)
+if [ ${#LEGACY_BACKUPS[@]} -gt 0 ]; then
+    mkdir -p "$LEGACY_BACKUPS_DIR"
+    for legacy_backup in "${LEGACY_BACKUPS[@]}"; do
+        base_name="$(basename "$legacy_backup")"
+        mv "$legacy_backup" "$LEGACY_BACKUPS_DIR/$base_name"
+    done
+    print_warning "Moved ${#LEGACY_BACKUPS[@]} legacy dotted backups to $LEGACY_BACKUPS_DIR to prevent Home Assistant from reloading them"
+else
+    print_status "No legacy dotted backups found in custom_components"
+fi
+
 # Copy the integration
 print_status "Copying Android TV Box integration..."
 if [ -d "$CUSTOM_COMPONENTS_DIR/android_tv_box" ]; then


### PR DESCRIPTION
## Summary
- move legacy dotted backup folders out of Home Assistant's custom_components directory during deployment
- log the cleanup activity so operators know why folders were touched
- document that the deploy script now performs this cleanup automatically

## Testing
- not run (script/documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68cdd72175ac8328a17c79c15501d4fe