### PR TITLE
fix: initialize coordinator data and align name field

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ The `ADBService` class in `adb_service.py` handles all ADB operations:
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   screenshot_path: "/sdcard/isgbackup/screenshot/"
   screenshot_keep_count: 3
   screenshot_interval: 3

--- a/HACS_INSTALLATION.md
+++ b/HACS_INSTALLATION.md
@@ -157,7 +157,7 @@ git clone https://github.com/bobo/android-tv-box.git android_tv_box
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "My Android TV Box"
+  name: "My Android TV Box"
   screenshot_path: "/sdcard/screenshots/"
   screenshot_keep_count: 5
   screenshot_interval: 5

--- a/HACS_PAGE.md
+++ b/HACS_PAGE.md
@@ -63,7 +63,7 @@ Access a beautiful web interface at `http://localhost:3003` for:
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   screenshot_path: "/sdcard/isgbackup/screenshot/"
   screenshot_keep_count: 3
   screenshot_interval: 3
@@ -73,6 +73,8 @@ android_tv_box:
   ubuntu_venv_path: "~/uiauto_env"
   adb_path: "/usr/bin/adb"
 ```
+
+> ℹ️ Legacy configs may still reference `device_name`; it is supported as an alias, but `name` is now preferred.
 
 ### Application Configuration
 ```yaml

--- a/HOME_ASSISTANT_INTEGRATION_TEST_REPORT.md
+++ b/HOME_ASSISTANT_INTEGRATION_TEST_REPORT.md
@@ -143,7 +143,7 @@ Status: Connected and responsive
 android_tv_box:
   host: "192.168.188.221"     # ✅ 正确的设备IP
   port: 5555                  # ✅ ADB TCP端口
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   screenshot_path: "/sdcard/isgbackup/screenshot/"  # ✅ 路径有效
   screenshot_keep_count: 3     # ✅ 清理机制工作
   screenshot_interval: 3       # ✅ 3秒间隔正常
@@ -151,6 +151,8 @@ android_tv_box:
   cpu_threshold: 50           # ✅ 阈值触发警告
   isg_monitoring: true        # ✅ iSG监控活跃
 ```
+
+> 说明：`device_name` 仍然作为兼容字段被接受，但推荐改用 `name` 以与最新配置向导保持一致。
 
 ## 性能表现
 

--- a/PROJECT_OVERVIEW.md
+++ b/PROJECT_OVERVIEW.md
@@ -130,7 +130,7 @@ android-control/
 android_tv_box:
   host: "127.0.0.1"                    # ADB主机地址
   port: 5555                           # ADB端口
-  device_name: "Android TV Box"        # 设备名称
+  name: "Android TV Box"               # 设备名称
   screenshot_path: "/sdcard/isgbackup/screenshot/"  # 截图路径
   screenshot_keep_count: 3              # 保留截图数量
   screenshot_interval: 3                # 截图间隔（秒）
@@ -140,6 +140,8 @@ android_tv_box:
   ubuntu_venv_path: "~/uiauto_env"      # Python虚拟环境路径
   adb_path: "/usr/bin/adb"             # ADB二进制路径
 ```
+
+> 提示：早期版本中使用的 `device_name` 字段依旧可用，但建议切换为标准的 `name`。
 
 ### 实体配置
 ```yaml

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The following Android devices are supported:
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   screenshot_path: "/sdcard/isgbackup/screenshot/"
   screenshot_keep_count: 3
   screenshot_interval: 3
@@ -109,6 +109,8 @@ android_tv_box:
   ubuntu_venv_path: "~/uiauto_env"
   adb_path: "/usr/bin/adb"
 ```
+
+> **Note:** Older configuration examples may use `device_name`. The integration still accepts this alias for backward compatibility, but new setups should prefer the standard Home Assistant `name` field.
 
 ### Application Configuration
 

--- a/custom_components/android_tv_box/README.md
+++ b/custom_components/android_tv_box/README.md
@@ -151,7 +151,7 @@ adb devices
    android_tv_box:
      host: "127.0.0.1"
      port: 5555
-     device_name: "Android TV Box"
+     name: "Android TV Box"
      screenshot_path: "/sdcard/isgbackup/screenshot/"
      screenshot_keep_count: 3
      screenshot_interval: 3
@@ -172,7 +172,8 @@ adb devices
 |--------|---------|-------------|
 | `host` | `127.0.0.1` | ADB host address |
 | `port` | `5555` | ADB port |
-| `device_name` | `Android TV Box` | Device name in Home Assistant |
+| `name` | `Android TV Box` | Device name in Home Assistant |
+| `device_name` | _(deprecated)_ | Legacy alias for `name`, still accepted |
 | `screenshot_path` | `/sdcard/isgbackup/screenshot/` | Screenshot storage path |
 | `screenshot_keep_count` | `3` | Number of screenshots to keep |
 | `screenshot_interval` | `3` | Screenshot interval in seconds |

--- a/custom_components/android_tv_box/binary_sensor.py
+++ b/custom_components/android_tv_box/binary_sensor.py
@@ -1,13 +1,13 @@
 """Binary Sensor platform for Android TV Box integration."""
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 from datetime import timedelta
 
 from homeassistant.components.binary_sensor import BinarySensorEntity, BinarySensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .helpers import get_adb_service, get_config
 from .adb_service import ADBService
@@ -107,6 +107,8 @@ async def async_setup_entry(
 
     # Create coordinator
     coordinator = AndroidTVBoxBinarySensorCoordinator(hass, adb_service, config)
+
+    await coordinator.async_config_entry_first_refresh()
     
     # Create binary sensor entities
     entities = [
@@ -143,7 +145,8 @@ class AndroidTVBoxConnectionSensor(BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if ADB is connected."""
-        return self.coordinator.data.get("adb_connected", False)
+        data = self.coordinator.data or {}
+        return data.get("adb_connected", False)
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
@@ -187,7 +190,8 @@ class AndroidTVBoxHighCPUWarningSensor(BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if CPU usage is high."""
-        return self.coordinator.data.get("high_cpu_warning", False)
+        data = self.coordinator.data or {}
+        return data.get("high_cpu_warning", False)
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
@@ -238,13 +242,15 @@ class AndroidTVBoxISGRunningSensor(BinarySensorEntity):
     @property
     def is_on(self) -> bool:
         """Return true if iSG is running."""
-        return self.coordinator.data.get("isg_running", False)
+        data = self.coordinator.data or {}
+        return data.get("isg_running", False)
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:
         """Return extra state attributes."""
+        data = self.coordinator.data or {}
         return {
-            "wake_attempted": self.coordinator.data.get("isg_wake_attempted", False),
+            "wake_attempted": data.get("isg_wake_attempted", False),
             "monitoring_enabled": self.config.get("isg_monitoring", True),
             "check_interval": self.config.get("isg_check_interval", 30),
         }

--- a/custom_components/android_tv_box/sensor.py
+++ b/custom_components/android_tv_box/sensor.py
@@ -1,13 +1,13 @@
 """Sensor platform for Android TV Box integration."""
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from datetime import timedelta
 
 from homeassistant.components.sensor import SensorEntity, SensorDeviceClass, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
 
 from .helpers import get_adb_service, get_config
@@ -126,6 +126,8 @@ async def async_setup_entry(
 
     # Create coordinator
     coordinator = AndroidTVBoxSensorCoordinator(hass, adb_service, config)
+
+    await coordinator.async_config_entry_first_refresh()
     
     # Create sensor entities
     entities = [
@@ -165,7 +167,8 @@ class AndroidTVBoxBrightnessSensor(SensorEntity):
     @property
     def native_value(self) -> Optional[int]:
         """Return the brightness value."""
-        return self.coordinator.data.get("brightness")
+        data = self.coordinator.data or {}
+        return data.get("brightness")
 
     @property
     def available(self) -> bool:
@@ -208,7 +211,8 @@ class AndroidTVBoxWiFiSSIDSensor(SensorEntity):
     @property
     def native_value(self) -> Optional[str]:
         """Return the WiFi SSID."""
-        return self.coordinator.data.get("ssid")
+        data = self.coordinator.data or {}
+        return data.get("ssid")
 
     @property
     def available(self) -> bool:
@@ -251,7 +255,8 @@ class AndroidTVBoxIPAddressSensor(SensorEntity):
     @property
     def native_value(self) -> Optional[str]:
         """Return the IP address."""
-        return self.coordinator.data.get("ip_address")
+        data = self.coordinator.data or {}
+        return data.get("ip_address")
 
     @property
     def available(self) -> bool:
@@ -294,7 +299,8 @@ class AndroidTVBoxCurrentAppSensor(SensorEntity):
     @property
     def native_value(self) -> Optional[str]:
         """Return the current app."""
-        return self.coordinator.data.get("current_app")
+        data = self.coordinator.data or {}
+        return data.get("current_app")
 
     @property
     def available(self) -> bool:
@@ -340,7 +346,8 @@ class AndroidTVBoxCPUUsageSensor(SensorEntity):
     @property
     def native_value(self) -> Optional[float]:
         """Return the CPU usage."""
-        return self.coordinator.data.get("cpu_usage")
+        data = self.coordinator.data or {}
+        return data.get("cpu_usage")
 
     @property
     def available(self) -> bool:
@@ -386,7 +393,8 @@ class AndroidTVBoxMemoryUsageSensor(SensorEntity):
     @property
     def native_value(self) -> Optional[int]:
         """Return the memory usage."""
-        return self.coordinator.data.get("memory_used")
+        data = self.coordinator.data or {}
+        return data.get("memory_used")
 
     @property
     def available(self) -> bool:
@@ -429,8 +437,9 @@ class AndroidTVBoxHighCPUWarningSensor(SensorEntity):
     @property
     def native_value(self) -> str:
         """Return the high CPU warning status."""
-        if self.coordinator.data.get("high_cpu_warning", False):
-            count = self.coordinator.data.get("high_cpu_count", 0)
+        data = self.coordinator.data or {}
+        if data.get("high_cpu_warning", False):
+            count = data.get("high_cpu_count", 0)
             return f"High CPU detected for {count} consecutive readings"
         return "Normal"
 

--- a/custom_components/android_tv_box/switch.py
+++ b/custom_components/android_tv_box/switch.py
@@ -1,13 +1,13 @@
 """Switch platform for Android TV Box integration."""
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 from datetime import timedelta
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 import asyncio
 
 from .helpers import get_adb_service, get_config
@@ -84,6 +84,8 @@ async def async_setup_entry(
     # Create coordinator
     coordinator = AndroidTVBoxSwitchCoordinator(hass, adb_service)
     
+    await coordinator.async_config_entry_first_refresh()
+
     # Create switch entities
     entities = [
         AndroidTVBoxPowerSwitch(coordinator, config),
@@ -115,7 +117,8 @@ class AndroidTVBoxPowerSwitch(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
-        return self.coordinator.data.get("power_on", False)
+        data = self.coordinator.data or {}
+        return data.get("power_on", False)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
@@ -168,7 +171,8 @@ class AndroidTVBoxWiFiSwitch(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if the switch is on."""
-        return self.coordinator.data.get("wifi_on", False)
+        data = self.coordinator.data or {}
+        return data.get("wifi_on", False)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
@@ -221,7 +225,8 @@ class AndroidTVBoxADBSwitch(SwitchEntity):
     @property
     def is_on(self) -> bool:
         """Return true if ADB is connected."""
-        return self.coordinator.data.get("adb_connected", False)
+        data = self.coordinator.data or {}
+        return data.get("adb_connected", False)
 
     @property
     def icon(self) -> str:

--- a/custom_components/android_tv_box/web/index_complete.html
+++ b/custom_components/android_tv_box/web/index_complete.html
@@ -1018,7 +1018,7 @@
                 // ADB settings
                 document.getElementById('adb-host').value = this.config.host || '';
                 document.getElementById('adb-port').value = this.config.port || '';
-                document.getElementById('device-name').value = this.config.device_name || '';
+                document.getElementById('device-name').value = this.config.name || this.config.device_name || '';
 
                 // Screenshot settings
                 document.getElementById('screenshot-path').value = this.config.screenshot_path || '';
@@ -1100,7 +1100,7 @@
                 const config = {
                     host: document.getElementById('adb-host').value,
                     port: parseInt(document.getElementById('adb-port').value),
-                    device_name: document.getElementById('device-name').value,
+                    name: document.getElementById('device-name').value,
                     screenshot_path: document.getElementById('screenshot-path').value,
                     screenshot_keep_count: parseInt(document.getElementById('screenshot-keep-count').value),
                     screenshot_interval: parseInt(document.getElementById('screenshot-interval').value),

--- a/custom_components/android_tv_box/web/index_enhanced.html
+++ b/custom_components/android_tv_box/web/index_enhanced.html
@@ -1020,7 +1020,7 @@
             // ADB settings
             document.getElementById('adb-host').value = config.host || '';
             document.getElementById('adb-port').value = config.port || '';
-            document.getElementById('device-name').value = config.device_name || '';
+            document.getElementById('device-name').value = config.name || config.device_name || '';
             
             // Screenshot settings
             document.getElementById('screenshot-path').value = config.screenshot_path || '';
@@ -1039,7 +1039,7 @@
             const newConfig = {
                 host: document.getElementById('adb-host').value,
                 port: parseInt(document.getElementById('adb-port').value),
-                device_name: document.getElementById('device-name').value,
+                name: document.getElementById('device-name').value,
                 screenshot_path: document.getElementById('screenshot-path').value,
                 screenshot_keep_count: parseInt(document.getElementById('screenshot-keep-count').value),
                 screenshot_interval: parseInt(document.getElementById('screenshot-interval').value),

--- a/custom_components/android_tv_box/web/index_simple.html
+++ b/custom_components/android_tv_box/web/index_simple.html
@@ -564,7 +564,7 @@
                         <div style="padding: 10px; background: #f5f5f5; border-radius: 5px; margin: 10px 0;">
                             <strong>ADB Host:</strong> ${data.data.host}<br>
                             <strong>ADB Port:</strong> ${data.data.port}<br>
-                            <strong>Device Name:</strong> ${data.data.device_name}<br>
+                            <strong>Device Name:</strong> ${data.data.name || data.data.device_name}<br>
                             <strong>CPU Threshold:</strong> ${data.data.cpu_threshold}%<br>
                             <strong>Termux Mode:</strong> ${data.data.termux_mode ? 'Enabled' : 'Disabled'}
                         </div>

--- a/deploy.sh
+++ b/deploy.sh
@@ -91,7 +91,7 @@ default_config:
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   screenshot_path: "/sdcard/isgbackup/screenshot/"
   screenshot_keep_count: 3
   screenshot_interval: 3
@@ -119,13 +119,13 @@ else
         print_warning "Please manually update your configuration if needed"
     else
         print_status "Adding Android TV Box configuration to configuration.yaml..."
-        cat >> "$CONFIG_FILE" << EOF
+cat >> "$CONFIG_FILE" << EOF
 
 # Android TV Box Integration
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   screenshot_path: "/sdcard/isgbackup/screenshot/"
   screenshot_keep_count: 3
   screenshot_interval: 3

--- a/info.md
+++ b/info.md
@@ -49,13 +49,15 @@ Access a beautiful web interface at `http://localhost:3003` for:
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   apps:
     YouTube: com.google.android.youtube
     Netflix: com.netflix.mediaclient
     iSG: com.linknlink.app.device.isg
   isg_monitoring: true
 ```
+
+> 兼容性提示：旧版本配置中的 `device_name` 仍可使用，但建议改用标准的 `name` 字段。
 
 ## 📊 Supported Entities
 

--- a/sample_configuration.yaml
+++ b/sample_configuration.yaml
@@ -4,7 +4,7 @@
 android_tv_box:
   host: "192.168.188.221"  # Change to your Android device IP
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   
   # Screenshot settings
   screenshot_path: "/sdcard/isgbackup/screenshot/"

--- a/setup_ubuntu.sh
+++ b/setup_ubuntu.sh
@@ -118,7 +118,7 @@ default_config:
 android_tv_box:
   host: "127.0.0.1"
   port: 5555
-  device_name: "Android TV Box"
+  name: "Android TV Box"
   screenshot_path: "/sdcard/isgbackup/screenshot/"
   screenshot_keep_count: 3
   screenshot_interval: 3

--- a/test_all_functions.py
+++ b/test_all_functions.py
@@ -114,7 +114,8 @@ async def test_all_functions():
                         print("   ✅ 配置管理正常")
                         print(f"      - ADB主机: {config.get('host', 'Unknown')}")
                         print(f"      - ADB端口: {config.get('port', 'Unknown')}")
-                        print(f"      - 设备名称: {config.get('device_name', 'Unknown')}")
+                        device_name = config.get('name') or config.get('device_name', 'Unknown')
+                        print(f"      - 设备名称: {device_name}")
                     else:
                         print("   ❌ 配置管理失败")
                 else:

--- a/test_complete_pages.py
+++ b/test_complete_pages.py
@@ -79,7 +79,8 @@ async def test_complete_pages():
                                 config = data['data']
                                 print(f"      - ADB主机: {config.get('host', 'Unknown')}")
                                 print(f"      - ADB端口: {config.get('port', 'Unknown')}")
-                                print(f"      - 设备名称: {config.get('device_name', 'Unknown')}")
+                                device_name = config.get('name') or config.get('device_name', 'Unknown')
+                                print(f"      - 设备名称: {device_name}")
                         else:
                             print(f"   ❌ {api_name} API返回错误: {data.get('error', 'Unknown')}")
                     else:
@@ -127,7 +128,7 @@ async def test_complete_pages():
             test_config = {
                 'host': '192.168.188.221',
                 'port': 5555,
-                'device_name': 'Test Device',
+                'name': 'Test Device',
                 'screenshot_path': '/tmp/screenshots/',
                 'screenshot_keep_count': 3,
                 'screenshot_interval': 3,

--- a/test_enhanced_features.py
+++ b/test_enhanced_features.py
@@ -107,7 +107,7 @@ async def test_enhanced_features():
             test_config = {
                 'host': '192.168.188.221',
                 'port': 5555,
-                'device_name': 'Test Device',
+                'name': 'Test Device',
                 'screenshot_path': '/tmp/screenshots/',
                 'screenshot_keep_count': 3,
                 'screenshot_interval': 3,

--- a/test_final.py
+++ b/test_final.py
@@ -63,7 +63,8 @@ async def test_final():
                         print("   ✅ 配置API正常")
                         print(f"      - ADB主机: {config.get('host', 'Unknown')}")
                         print(f"      - ADB端口: {config.get('port', 'Unknown')}")
-                        print(f"      - 设备名称: {config.get('device_name', 'Unknown')}")
+                        device_name = config.get('name') or config.get('device_name', 'Unknown')
+                        print(f"      - 设备名称: {device_name}")
                     else:
                         print("   ❌ 配置API失败")
                 else:

--- a/test_restored_page.py
+++ b/test_restored_page.py
@@ -114,7 +114,8 @@ async def test_restored_page():
                         print("   ✅ 配置管理正常")
                         print(f"      - ADB主机: {config.get('host', 'Unknown')}")
                         print(f"      - ADB端口: {config.get('port', 'Unknown')}")
-                        print(f"      - 设备名称: {config.get('device_name', 'Unknown')}")
+                        device_name = config.get('name') or config.get('device_name', 'Unknown')
+                        print(f"      - 设备名称: {device_name}")
                     else:
                         print("   ❌ 配置管理失败")
                 else:

--- a/test_simple_page.py
+++ b/test_simple_page.py
@@ -98,7 +98,8 @@ async def test_simple_page():
                         print("   ✅ 配置 API正常")
                         print(f"      - ADB主机: {config.get('host', 'Unknown')}")
                         print(f"      - ADB端口: {config.get('port', 'Unknown')}")
-                        print(f"      - 设备名称: {config.get('device_name', 'Unknown')}")
+                        device_name = config.get('name') or config.get('device_name', 'Unknown')
+                        print(f"      - 设备名称: {device_name}")
                     else:
                         print("   ❌ 配置API返回错误")
                 else:


### PR DESCRIPTION
## Summary
- initialize DataUpdateCoordinators before entity creation and guard entity properties when coordinator data is unavailable
- accept legacy `device_name` input in the config flow while standardizing configuration examples and tooling on the `name` field
- refresh documentation, helper scripts, tests, and web UI to reference the `name` option and note the legacy alias

## Testing
- python -m compileall custom_components/android_tv_box

------
https://chatgpt.com/codex/tasks/task_e_68ce2d2004608328a406976b723f61fa