### PR TITLE
fix: target device when pulling screenshots

### DIFF
--- a/custom_components/android_tv_box/adb_service.py
+++ b/custom_components/android_tv_box/adb_service.py
@@ -109,6 +109,20 @@ class ADBService:
             process.kill()
             raise subprocess.TimeoutExpired(full_cmd, timeout)
 
+    async def pull_file(self, remote_path: str, local_path: str) -> bool:
+        """Pull a file from the device to the local filesystem."""
+        if not self._connected:
+            if not await self.connect():
+                raise ADBConnectionError("Device not connected")
+
+        try:
+            cmd = ["-s", self.device_address, "pull", remote_path, local_path]
+            await self._run_command(cmd)
+            return True
+        except Exception as err:
+            _LOGGER.error(f"ADB pull failed: {err}")
+            raise ADBConnectionError(f"Command failed: {remote_path}") from err
+
     # Media Player Commands
     async def media_play(self) -> bool:
         """Start media playback."""

--- a/custom_components/android_tv_box/camera.py
+++ b/custom_components/android_tv_box/camera.py
@@ -141,9 +141,12 @@ class AndroidTVBoxCameraCoordinator(DataUpdateCoordinator):
             temp_file = f"{temp_dir}/screenshot_{datetime.now().timestamp()}.png"
             
             # Use adb pull to get the file
-            cmd = ["pull", latest_file, temp_file]
-            result = await self.adb_service._run_command(cmd)
-            
+            try:
+                await self.adb_service.pull_file(latest_file, temp_file)
+            except Exception as err:
+                _LOGGER.error(f"Failed to pull screenshot {latest_file}: {err}")
+                return None
+
             if os.path.exists(temp_file):
                 try:
                     with open(temp_file, 'rb') as f:
@@ -160,7 +163,7 @@ class AndroidTVBoxCameraCoordinator(DataUpdateCoordinator):
                     if os.path.exists(temp_file):
                         os.remove(temp_file)
             else:
-                _LOGGER.error(f"Failed to pull screenshot: {latest_file}")
+                _LOGGER.error(f"Screenshot file missing after pull: {latest_file}")
                 return None
                 
         except Exception as e:


### PR DESCRIPTION
## Summary
- add dedicated pull helper in the ADB service so pulls always target the configured device
- use the new helper from the camera platform and improve error handling when retrieving screenshots

## Testing
- python -m compileall custom_components/android_tv_box

------
https://chatgpt.com/codex/tasks/task_e_68ce340ff4c08328a78476da8a749b13